### PR TITLE
ci: configure bazel setup caching

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+        with:
+          bazelrc: common --config=ci
+          bazelisk-cache: true
+          disk-cache: true
+          external-cache: true
+          repository-cache: true
+          cache-save: ${{ github.event_name != 'pull_request' }}
       - name: "Build & Test"
         shell: bash
-        run: bazel test --config=ci //...
+        run: bazel test //...


### PR DESCRIPTION
- Enable `setup-bazel` caching for Bazelisk, disk, external, and repository caches
- Move `--config=ci` into the generated bazelrc configuration
- Avoid saving caches from pull request runs